### PR TITLE
modified request function to stringify payloads

### DIFF
--- a/lib/syncano4.js
+++ b/lib/syncano4.js
@@ -2316,6 +2316,9 @@ var Syncano = (function() {
 				callbackError('Missing request method');
 			} else {
 				params = params || {};
+				if (params.payload !== 'undefined') {
+					params.payload = JSON.stringify(params.payload);
+				}
 				var url = normalizeUrl(baseURL + method);
 				if (apiKey !== null) {
 					url += (url.indexOf('?') === -1 ? '?' : '&') + 'api_key=' + apiKey + '&format=json';


### PR DESCRIPTION
Sorry for the additional PR for this. I realized later that the `payload` needed to be stringified to run correctly.